### PR TITLE
hotfix: AI 자기소개서 생성 시 등록된 게시글이 없을 경우 발생하는 예외처리 누락 로직 추가

### DIFF
--- a/src/main/java/com/project/hiuni/domain/record/coverletter/v1/service/CoverLetterV1Service.java
+++ b/src/main/java/com/project/hiuni/domain/record/coverletter/v1/service/CoverLetterV1Service.java
@@ -138,6 +138,10 @@ public class CoverLetterV1Service {
       log.error("유저를 찾을 수 없습니다.: {}", e.getMessage());
       throw e;
 
+    } catch (CustomPostNotFoundException e) {
+      log.error("해당 게시글을 찾을 수 없습니다.: {}", e.getMessage());
+      throw e;
+
     } catch (InsufficientGenerationCountException e) {
       log.error("생성 가능 횟수가 0 이하임: {}", e.getMessage());
       throw e;


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- hotfix/#199

📄  **작업한 내용**
- AI 자기소개서 생성 시 등록된 게시글이 없을 경우 발생하는 예외처리 누락 로직 추가

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 💻 관련 이슈
- Resolved: #199

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.