### PR TITLE
hotfix: AI 자기소개서 생성 시 등록된 게시글이 없을 경우 발생하는 예외처리 누락 로직 추가

### DIFF
--- a/src/main/java/com/project/hiuni/domain/record/coverletter/v1/service/CoverLetterV1Service.java
+++ b/src/main/java/com/project/hiuni/domain/record/coverletter/v1/service/CoverLetterV1Service.java
@@ -138,6 +138,10 @@ public class CoverLetterV1Service {
       log.error("유저를 찾을 수 없습니다.: {}", e.getMessage());
       throw e;
 
+    } catch (CustomPostNotFoundException e) {
+      log.error("해당 게시글을 찾을 수 없습니다.: {}", e.getMessage());
+      throw e;
+
     } catch (InsufficientGenerationCountException e) {
       log.error("생성 가능 횟수가 0 이하임: {}", e.getMessage());
       throw e;


### PR DESCRIPTION
hotfix: AI 자기소개서 생성 시 등록된 게시글이 없을 경우 발생하는 예외처리 누락 로직 추가