### PR TITLE
Hotfix : 주간 핫 게시글 조회 방식을 API 호출시의 시점으로 수정

### DIFF
--- a/src/main/java/com/project/hiuni/domain/post/common/WeekRange.java
+++ b/src/main/java/com/project/hiuni/domain/post/common/WeekRange.java
@@ -1,0 +1,23 @@
+package com.project.hiuni.domain.post.common;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public final class WeekRange {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    private WeekRange() {}
+
+    public static LocalDateTime start() {
+        return LocalDate.now(ZONE)
+                .with(DayOfWeek.SUNDAY)
+                .atStartOfDay();
+    }
+
+    public static LocalDateTime end() {
+        return LocalDateTime.now(ZONE);
+    }
+}

--- a/src/main/java/com/project/hiuni/domain/post/v1/service/PostV1Service.java
+++ b/src/main/java/com/project/hiuni/domain/post/v1/service/PostV1Service.java
@@ -4,6 +4,7 @@ import com.project.hiuni.domain.bookmark.repository.BookmarkRepository;
 import com.project.hiuni.domain.post.common.PostPreviewMapper;
 import com.project.hiuni.domain.comment.projection.PostCommentCount;
 import com.project.hiuni.domain.comment.repository.CommentRepository;
+import com.project.hiuni.domain.post.common.WeekRange;
 import com.project.hiuni.domain.post.dto.request.PostCreateNoReviewRequest;
 import com.project.hiuni.domain.post.dto.request.PostCreateReviewRequest;
 import com.project.hiuni.domain.post.dto.request.PostUpdateNoReviewRequest;
@@ -40,10 +41,7 @@ import com.project.hiuni.domain.user.entity.User;
 import com.project.hiuni.domain.user.exception.CustomUserNotFoundException;
 import com.project.hiuni.domain.user.repository.UserRepository;
 import com.project.hiuni.global.exception.ErrorCode;
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -421,11 +419,8 @@ public class PostV1Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomUserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        ZoneId zone = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zone);
-
-        LocalDateTime end   = today.with(DayOfWeek.SUNDAY).atStartOfDay();
-        LocalDateTime start = end.minusWeeks(1);
+        LocalDateTime start = WeekRange.start();
+        LocalDateTime end   = WeekRange.end();
 
         List<Post> posts = postRepository.findWeeklyHot(start, end, user.getUnivName())
                 .stream()
@@ -442,11 +437,8 @@ public class PostV1Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomUserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        ZoneId zone = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zone);
-
-        LocalDateTime end   = today.with(DayOfWeek.SUNDAY).atStartOfDay();
-        LocalDateTime start = end.minusWeeks(1);
+        LocalDateTime start = WeekRange.start();
+        LocalDateTime end   = WeekRange.end();
 
         List<Post> posts = postRepository.findWeeklyHot(start, end, user.getUnivName())
                 .stream()
@@ -532,11 +524,8 @@ public class PostV1Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomUserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        ZoneId zone = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zone);
-
-        LocalDateTime end   = today.with(DayOfWeek.SUNDAY).atStartOfDay();
-        LocalDateTime start = end.minusWeeks(1);
+        LocalDateTime start = WeekRange.start();
+        LocalDateTime end   = WeekRange.end();
 
         List<Post> posts=postRepository
                 .findWeeklyHotByType(start,end,user.getUnivName(),type)
@@ -556,11 +545,8 @@ public class PostV1Service {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomUserNotFoundException(ErrorCode.USER_NOT_FOUND));
 
-        ZoneId zone = ZoneId.of("Asia/Seoul");
-        LocalDate today = LocalDate.now(zone);
-
-        LocalDateTime end   = today.with(DayOfWeek.SUNDAY).atStartOfDay();
-        LocalDateTime start = end.minusWeeks(1);
+        LocalDateTime start = WeekRange.start();
+        LocalDateTime end   = WeekRange.end();
 
         List<Post> posts = postRepository
                 .findWeeklyHotByCategory(start, end, user.getUnivName(), category)


### PR DESCRIPTION
## 🔥*Pull requests*

#️⃣️ **작업한 브랜치**
- hotfix/#242/weekly-hot-bug-solve

📄  **작업한 내용**
일요일에 주간 hot 게시글이 정상적으로 나오지 않는 문제가 발생하여 조회 방식을 API 호출시의 시점으로 수정

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

## 💻 관련 이슈
- Resolved: #242 

## 💬 리뷰 요구사항 (선택)
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해 주세요 -->
- 예: 이 부분의 로직이 적절한지 확인 부탁드립니다.